### PR TITLE
Fix SelectedFilters mutating the state

### DIFF
--- a/app/sensors/SelectedFilters.js
+++ b/app/sensors/SelectedFilters.js
@@ -29,7 +29,7 @@ export default class SelectedFilters extends Component {
 
 	updateSensors(data) {
 		let isanyChange = false;
-		let filters = { ...this.state.filters };
+		let { filters } = this.state;
 		Object.keys(data).forEach(item => {
 			const selectedFilter = this.isSibling(item);
 			if (selectedFilter) {
@@ -68,7 +68,7 @@ export default class SelectedFilters extends Component {
 	}
 
 	clearFilter(item) {
-		let filters = { ...this.state.filters };
+		const { filters } = this.state;
 		delete filters[item];
 		this.setState({
 			filters

--- a/app/sensors/SelectedFilters.js
+++ b/app/sensors/SelectedFilters.js
@@ -29,7 +29,7 @@ export default class SelectedFilters extends Component {
 
 	updateSensors(data) {
 		let isanyChange = false;
-		let filters = this.state.filters;
+		let filters = { ...this.state.filters };
 		Object.keys(data).forEach(item => {
 			const selectedFilter = this.isSibling(item);
 			if (selectedFilter) {

--- a/app/sensors/SelectedFilters.js
+++ b/app/sensors/SelectedFilters.js
@@ -68,7 +68,7 @@ export default class SelectedFilters extends Component {
 	}
 
 	clearFilter(item) {
-		let filters = this.state.filters;
+		let filters = { ...this.state.filters };
 		delete filters[item];
 		this.setState({
 			filters


### PR DESCRIPTION
`SelectedFilters` was accidentally mutating the `state`. This also fixes a bug when the `SelectedFilters` would still remain visible when all the filters were removed