### PR TITLE
Remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "lodash": "^4.17.4",
     "moment": "^2.14.1",
     "rc-slider": "^5.4.0",
-    "react-addons-shallow-compare": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
     "react-autosuggest": "^9.0.1",
     "react-dates": "^4.3.0",
     "react-moment-proptypes": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7041,17 +7041,6 @@ react-addons-create-fragment@^15.5.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-addons-shallow-compare@^15.4.2:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.0.tgz#b7a4e5ff9f2704c20cf686dd8a05dd08b26de252"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
-react-addons-test-utils@^15.4.2:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
-
 react-autosuggest@^9.0.1:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.2.tgz#dd8c0fbe9c25aa94afe296180353647f6ecc10a7"


### PR DESCRIPTION
Unused deps:
 - react-addons-shallow-compare
 - react-addons-test-utils

Removing these seems to causing issue with [react-select which still uses these react-addons](https://github.com/airbnb/react-dates/blob/master/package.json#L91-L92) but why are they present in reactivebase's package.json?

![image](https://user-images.githubusercontent.com/5961873/31057213-9fcfe1d6-a6fc-11e7-99e1-6b8a94c791c1.png)
